### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -65,6 +65,6 @@ p6df::modules::dbt::langs() {
 ######################################################################
 p6df::modules::dbt::profile::mod() {
 
-  p6_return_words 'dbt' '$DBT_PROFILES_DIR'
+  p6_return_words 'dbt' "$"
 }
 

--- a/init.zsh
+++ b/init.zsh
@@ -51,3 +51,20 @@ p6df::modules::dbt::langs() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words dbt $DBT_PROFILES_DIR = p6df::modules::dbt::profile::mod()
+#
+#  Returns:
+#	words - dbt $DBT_PROFILES_DIR
+#
+#  Environment:	 DBT_PROFILES_DIR
+#>
+######################################################################
+p6df::modules::dbt::profile::mod() {
+
+  p6_return_words 'dbt' '$DBT_PROFILES_DIR'
+}
+


### PR DESCRIPTION
## What
Adds `profile::mod` to the dbt module using `p6_return_words 'dbt' '$DBT_PROFILES_DIR'`.

## Why
Implements the new prompt dispatch model where `profile::mod` returns label and variable tokens as separate args to `p6_return_words`.

## Test plan
- Source module and verify `p6df::modules::dbt::profile::mod` is defined
- Confirm prompt shows dbt profiles dir when `$DBT_PROFILES_DIR` is set

## Dependencies
None