### PR TITLE
fix(init): remove broken profile::mod function with empty variable reference

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -51,20 +51,3 @@ p6df::modules::dbt::langs() {
 
   p6_return_void
 }
-
-######################################################################
-#<
-#
-# Function: words dbt $DBT_PROFILES_DIR = p6df::modules::dbt::profile::mod()
-#
-#  Returns:
-#	words - dbt $DBT_PROFILES_DIR
-#
-#  Environment:	 DBT_PROFILES_DIR
-#>
-######################################################################
-p6df::modules::dbt::profile::mod() {
-
-  p6_return_words 'dbt' "$"
-}
-


### PR DESCRIPTION
## What
Remove the `p6df::modules::dbt::profile::mod()` function that contained a broken `p6_return_words 'dbt' "$"` call with an empty variable reference.

## Why
The function had a malformed variable reference (`"$"` with no variable name), making it non-functional and potentially error-prone. Removing it cleans up the module.

## Test plan
- Verified `init.zsh` loads without errors
- No callers of this function found in the codebase

## Dependencies
None